### PR TITLE
Reworked image loading and added the ability to center text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,6 +315,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "lebe"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -679,6 +685,7 @@ version = "0.1.2"
 dependencies = [
  "image",
  "imageproc",
+ "lazy_static",
  "num-complex",
  "rusttype",
  "screeps-game-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["graphics", "multimedia::images", "visualization"]
 [dependencies]
 image = "0.24.9"
 imageproc = "0.23.0"
+lazy_static = "1.5.0"
 num-complex = "0.4.5"
 rusttype = "0.9.3"
 screeps-game-api = "0.21"

--- a/src/assets_data.rs
+++ b/src/assets_data.rs
@@ -1,134 +1,77 @@
-
-
-#[cfg(target_family = "unix")]
-pub const FREE_MONO_FONT_DATA: &[u8] = include_bytes!("assets/fonts/FreeMono.ttf");
-
-#[cfg(target_family = "unix")]
-pub const TERRAIN_PLAIN_IMG_DATA: &[u8] = include_bytes!("assets/terrains/plain.png");
-#[cfg(target_family = "unix")]
-pub const TERRAIN_SWAMP_IMG_DATA: &[u8] = include_bytes!("assets/terrains/swamp.png");
-#[cfg(target_family = "unix")]
-pub const TERRAIN_WALL_IMG_DATA: &[u8] = include_bytes!("assets/terrains/wall.png");
+use lazy_static::lazy_static;
+use std::io::Cursor;
+use std::io;
+use image::io::Reader;
+use image::RgbaImage;
 
 #[cfg(target_family = "unix")]
-pub const RESOURCE_SOURCE_IMG_DATA: &[u8] = include_bytes!("assets/resources/source.png");
-#[cfg(target_family = "unix")]
-pub const RESOURCE_HYDROGEN_IMG_DATA: &[u8] = include_bytes!("assets/resources/H.png");
-#[cfg(target_family = "unix")]
-pub const RESOURCE_OXYGEN_IMG_DATA: &[u8] = include_bytes!("assets/resources/O.png");
-#[cfg(target_family = "unix")]
-pub const RESOURCE_KEANIUM_IMG_DATA: &[u8] = include_bytes!("assets/resources/K.png");
-#[cfg(target_family = "unix")]
-pub const RESOURCE_LEMERGIUM_IMG_DATA: &[u8] = include_bytes!("assets/resources/L.png");
-#[cfg(target_family = "unix")]
-pub const RESOURCE_UTRIUM_IMG_DATA: &[u8] = include_bytes!("assets/resources/U.png");
-#[cfg(target_family = "unix")]
-pub const RESOURCE_ZYNTHIUM_IMG_DATA: &[u8] = include_bytes!("assets/resources/Z.png");
-#[cfg(target_family = "unix")]
-pub const RESOURCE_CATALYST_IMG_DATA: &[u8] = include_bytes!("assets/resources/X.png");
-#[cfg(target_family = "unix")]
-pub const RESOURCE_UNKNOWN_IMG_DATA: &[u8] = include_bytes!("assets/resources/unknown.png");
-
-#[cfg(target_family = "unix")]
-pub const STRUCTURE_CONSTRUCTEDWALL_IMG_DATA: &[u8] = include_bytes!("assets/structures/constructedWall.png");
-#[cfg(target_family = "unix")]
-pub const STRUCTURE_CONTAINER_IMG_DATA: &[u8] = include_bytes!("assets/structures/container.png");
-#[cfg(target_family = "unix")]
-pub const STRUCTURE_CONTROLLER_IMG_DATA: &[u8] = include_bytes!("assets/structures/controller.png");
-#[cfg(target_family = "unix")]
-pub const STRUCTURE_EXTENSION_IMG_DATA: &[u8] = include_bytes!("assets/structures/extension.png");
-#[cfg(target_family = "unix")]
-pub const STRUCTURE_EXTRACTOR_IMG_DATA: &[u8] = include_bytes!("assets/structures/extractor.png");
-#[cfg(target_family = "unix")]
-pub const STRUCTURE_FACTORY_IMG_DATA: &[u8] = include_bytes!("assets/structures/factory.png");
-#[cfg(target_family = "unix")]
-pub const STRUCTURE_LAB_IMG_DATA: &[u8] = include_bytes!("assets/structures/lab.png");
-#[cfg(target_family = "unix")]
-pub const STRUCTURE_LINK_IMG_DATA: &[u8] = include_bytes!("assets/structures/link.png");
-#[cfg(target_family = "unix")]
-pub const STRUCTURE_NUKER_IMG_DATA: &[u8] = include_bytes!("assets/structures/nuker.png");
-#[cfg(target_family = "unix")]
-pub const STRUCTURE_OBSERVER_IMG_DATA: &[u8] = include_bytes!("assets/structures/observer.png");
-#[cfg(target_family = "unix")]
-pub const STRUCTURE_POWERSPAWN_IMG_DATA: &[u8] = include_bytes!("assets/structures/powerSpawn.png");
-#[cfg(target_family = "unix")]
-pub const STRUCTURE_RAMPART_IMG_DATA: &[u8] = include_bytes!("assets/structures/rampart.png");
-#[cfg(target_family = "unix")]
-pub const STRUCTURE_ROAD_IMG_DATA: &[u8] = include_bytes!("assets/structures/road.png");
-#[cfg(target_family = "unix")]
-pub const STRUCTURE_SPAWN_IMG_DATA: &[u8] = include_bytes!("assets/structures/spawn.png");
-#[cfg(target_family = "unix")]
-pub const STRUCTURE_STORAGE_IMG_DATA: &[u8] = include_bytes!("assets/structures/storage.png");
-#[cfg(target_family = "unix")]
-pub const STRUCTURE_TERMINAL_IMG_DATA: &[u8] = include_bytes!("assets/structures/terminal.png");
-#[cfg(target_family = "unix")]
-pub const STRUCTURE_TOWER_IMG_DATA: &[u8] = include_bytes!("assets/structures/tower.png");
-#[cfg(target_family = "unix")]
-pub const STRUCTURE_UNKNOWN_IMG_DATA: &[u8] = include_bytes!("assets/structures/icon.png");
-
+macro_rules! include_asset {($folder:literal, $filename:literal) => (
+  include_bytes!(concat!("assets/", $folder, "/", $filename))
+)}
 
 #[cfg(target_family = "windows")]
-pub const FREE_MONO_FONT_DATA: &[u8] = include_bytes!(r"assets\fonts\FreeMono.ttf");
+macro_rules! include_asset {(filename:str) => (
+  include_bytes!(concat!(r"assets\", $folder, r"\", $filename))
+)}
 
-#[cfg(target_family = "windows")]
-pub const TERRAIN_PLAIN_IMG_DATA: &[u8] = include_bytes!(r"assets\terrains\plain.png");
-#[cfg(target_family = "windows")]
-pub const TERRAIN_SWAMP_IMG_DATA: &[u8] = include_bytes!(r"assets\terrains\swamp.png");
-#[cfg(target_family = "windows")]
-pub const TERRAIN_WALL_IMG_DATA: &[u8] = include_bytes!(r"assets\terrains\wall.png");
+fn decode_image_data(image_data: &[u8]) -> Result<RgbaImage, io::Error> {
+  let tile_img_reader = Reader::new(Cursor::new(image_data))
+    .with_guessed_format()?;
+  let tile_img_dynamic = tile_img_reader.decode()
+    .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+  Ok(tile_img_dynamic.to_rgba8())
+}
 
-#[cfg(target_family = "windows")]
-pub const RESOURCE_SOURCE_IMG_DATA: &[u8] = include_bytes!(r"assets\resources\source.png");
-#[cfg(target_family = "windows")]
-pub const RESOURCE_HYDROGEN_IMG_DATA: &[u8] = include_bytes!(r"assets\resources\H.png");
-#[cfg(target_family = "windows")]
-pub const RESOURCE_OXYGEN_IMG_DATA: &[u8] = include_bytes!(r"assets\resources\O.png");
-#[cfg(target_family = "windows")]
-pub const RESOURCE_KEANIUM_IMG_DATA: &[u8] = include_bytes!(r"assets\resources\K.png");
-#[cfg(target_family = "windows")]
-pub const RESOURCE_LEMERGIUM_IMG_DATA: &[u8] = include_bytes!(r"assets\resources\L.png");
-#[cfg(target_family = "windows")]
-pub const RESOURCE_UTRIUM_IMG_DATA: &[u8] = include_bytes!(r"assets\resources\U.png");
-#[cfg(target_family = "windows")]
-pub const RESOURCE_ZYNTHIUM_IMG_DATA: &[u8] = include_bytes!(r"assets\resources\Z.png");
-#[cfg(target_family = "windows")]
-pub const RESOURCE_CATALYST_IMG_DATA: &[u8] = include_bytes!(r"assets\resources\X.png");
-#[cfg(target_family = "windows")]
-pub const RESOURCE_UNKNOWN_IMG_DATA: &[u8] = include_bytes!(r"assets\resources\unknown.png");
+macro_rules! include_image {($folder:literal, $filename:literal) => (
+  decode_image_data(include_asset!($folder, $filename))
+    .expect(&format!("Could not decode image {}/{}", $folder, $filename))
+)}
 
-#[cfg(target_family = "windows")]
-pub const STRUCTURE_CONSTRUCTEDWALL_IMG_DATA: &[u8] = include_bytes!(r"assets\structures\constructedWall.png");
-#[cfg(target_family = "windows")]
-pub const STRUCTURE_CONTAINER_IMG_DATA: &[u8] = include_bytes!(r"assets\structures\container.png");
-#[cfg(target_family = "windows")]
-pub const STRUCTURE_CONTROLLER_IMG_DATA: &[u8] = include_bytes!(r"assets\structures\controller.png");
-#[cfg(target_family = "windows")]
-pub const STRUCTURE_EXTENSION_IMG_DATA: &[u8] = include_bytes!(r"assets\structures\extension.png");
-#[cfg(target_family = "windows")]
-pub const STRUCTURE_EXTRACTOR_IMG_DATA: &[u8] = include_bytes!(r"assets\structures\extractor.png");
-#[cfg(target_family = "windows")]
-pub const STRUCTURE_FACTORY_IMG_DATA: &[u8] = include_bytes!(r"assets\structures\factory.png");
-#[cfg(target_family = "windows")]
-pub const STRUCTURE_LAB_IMG_DATA: &[u8] = include_bytes!(r"assets\structures\lab.png");
-#[cfg(target_family = "windows")]
-pub const STRUCTURE_LINK_IMG_DATA: &[u8] = include_bytes!(r"assets\structures\link.png");
-#[cfg(target_family = "windows")]
-pub const STRUCTURE_NUKER_IMG_DATA: &[u8] = include_bytes!(r"assets\structures\nuker.png");
-#[cfg(target_family = "windows")]
-pub const STRUCTURE_OBSERVER_IMG_DATA: &[u8] = include_bytes!(r"assets\structures\observer.png");
-#[cfg(target_family = "windows")]
-pub const STRUCTURE_POWERSPAWN_IMG_DATA: &[u8] = include_bytes!(r"assets\structures\powerSpawn.png");
-#[cfg(target_family = "windows")]
-pub const STRUCTURE_RAMPART_IMG_DATA: &[u8] = include_bytes!(r"assets\structures\rampart.png");
-#[cfg(target_family = "windows")]
-pub const STRUCTURE_ROAD_IMG_DATA: &[u8] = include_bytes!(r"assets\structures\road.png");
-#[cfg(target_family = "windows")]
-pub const STRUCTURE_SPAWN_IMG_DATA: &[u8] = include_bytes!(r"assets\structures\spawn.png");
-#[cfg(target_family = "windows")]
-pub const STRUCTURE_STORAGE_IMG_DATA: &[u8] = include_bytes!(r"assets\structures\storage.png");
-#[cfg(target_family = "windows")]
-pub const STRUCTURE_TERMINAL_IMG_DATA: &[u8] = include_bytes!(r"assets\structures\terminal.png");
-#[cfg(target_family = "windows")]
-pub const STRUCTURE_TOWER_IMG_DATA: &[u8] = include_bytes!(r"assets\structures\tower.png");
-#[cfg(target_family = "windows")]
-pub const STRUCTURE_UNKNOWN_IMG_DATA: &[u8] = include_bytes!(r"assets\structures\icon.png");
+// To use these resources, you need to do `&NAME` or `&*NAME`.
+//
+// The way that this works is that under the hood, `lazy_static` creates a unique
+// type that has a dereference operator `*` that initializes the value if needed
+// and otherwise just returns the stored value.
+//
+// In a match statement where multiple of these are returned from different branches,
+// just a `&NAME` can cause problems for type inference. Using either a type
+// annotation of `&OutputImage` or `&RgbaImage` on the resulting variable can
+// fix this, or you can use `&*NAME`.
+lazy_static! {
+  pub static ref FREE_MONO_FONT: rusttype::Font<'static> =
+    rusttype::Font::try_from_bytes(include_asset!("fonts", "FreeMono.ttf"))
+    .expect("Could not load FreeMono font");
+
+  pub static ref TERRAIN_PLAIN_IMG: RgbaImage = include_image!("terrains", "plain.png");
+  pub static ref TERRAIN_SWAMP_IMG: RgbaImage = include_image!("terrains", "swamp.png");
+  pub static ref TERRAIN_WALL_IMG: RgbaImage = include_image!("terrains", "wall.png");
+
+  pub static ref RESOURCE_SOURCE_IMG: RgbaImage = include_image!("resources", "source.png");
+  pub static ref RESOURCE_HYDROGEN_IMG: RgbaImage = include_image!("resources", "H.png");
+  pub static ref RESOURCE_OXYGEN_IMG: RgbaImage = include_image!("resources", "O.png");
+  pub static ref RESOURCE_KEANIUM_IMG: RgbaImage = include_image!("resources", "K.png");
+  pub static ref RESOURCE_LEMERGIUM_IMG: RgbaImage = include_image!("resources", "L.png");
+  pub static ref RESOURCE_UTRIUM_IMG: RgbaImage = include_image!("resources", "U.png");
+  pub static ref RESOURCE_ZYNTHIUM_IMG: RgbaImage = include_image!("resources", "Z.png");
+  pub static ref RESOURCE_CATALYST_IMG: RgbaImage = include_image!("resources", "X.png");
+  pub static ref RESOURCE_UNKNOWN_IMG: RgbaImage = include_image!("resources", "unknown.png");
+
+  pub static ref STRUCTURE_CONSTRUCTEDWALL_IMG: RgbaImage = include_image!("structures", "constructedWall.png");
+  pub static ref STRUCTURE_CONTAINER_IMG: RgbaImage = include_image!("structures", "container.png");
+  pub static ref STRUCTURE_CONTROLLER_IMG: RgbaImage = include_image!("structures", "controller.png");
+  pub static ref STRUCTURE_EXTENSION_IMG: RgbaImage = include_image!("structures", "extension.png");
+  pub static ref STRUCTURE_EXTRACTOR_IMG: RgbaImage = include_image!("structures", "extractor.png");
+  pub static ref STRUCTURE_FACTORY_IMG: RgbaImage = include_image!("structures", "factory.png");
+  pub static ref STRUCTURE_LAB_IMG: RgbaImage = include_image!("structures", "lab.png");
+  pub static ref STRUCTURE_LINK_IMG: RgbaImage = include_image!("structures", "link.png");
+  pub static ref STRUCTURE_NUKER_IMG: RgbaImage = include_image!("structures", "nuker.png");
+  pub static ref STRUCTURE_OBSERVER_IMG: RgbaImage = include_image!("structures", "observer.png");
+  pub static ref STRUCTURE_POWERSPAWN_IMG: RgbaImage = include_image!("structures", "powerSpawn.png");
+  pub static ref STRUCTURE_RAMPART_IMG: RgbaImage = include_image!("structures", "rampart.png");
+  pub static ref STRUCTURE_ROAD_IMG: RgbaImage = include_image!("structures", "road.png");
+  pub static ref STRUCTURE_SPAWN_IMG: RgbaImage = include_image!("structures", "spawn.png");
+  pub static ref STRUCTURE_STORAGE_IMG: RgbaImage = include_image!("structures", "storage.png");
+  pub static ref STRUCTURE_TERMINAL_IMG: RgbaImage = include_image!("structures", "terminal.png");
+  pub static ref STRUCTURE_TOWER_IMG: RgbaImage = include_image!("structures", "tower.png");
+  pub static ref STRUCTURE_UNKNOWN_IMG: RgbaImage = include_image!("structures", "icon.png");
+}


### PR DESCRIPTION
Forgot to properly separate the two sections out into different commits/PRs, but I kind of did both at the same time.

Advantages:
- found a way to avoid duplicating all of the assets for both unix and linux.
- uses the lazy_static macro to parse the fonts and images only once.
- removed all of the duplicate `Reader::new(Cursor::new(...)).with_guessed_format()`.
- Errors when parsing the images no longer silently fail.

Notable potential problems:
- more macros involved in the image loading. But since we already need `include_asset` to deal with windows vs linux directory separators, `include_image` is equally simple and easy to understand so I don't think it's extra overhead. 
- the way lazy static interacts with type inference can cause some weird problems when returning images from different branches of a match statement. I put a comment at the declaration of everything to explain what can happen and how to deal with it.